### PR TITLE
replace deprecated DatetimeAwareJSONEnconding with DjangoJSONEncoding

### DIFF
--- a/dynamicresponse/emitters.py
+++ b/dynamicresponse/emitters.py
@@ -6,11 +6,11 @@ http://bitbucket.org/jespern/django-piston
 from __future__ import generators
 from django.db.models.query import QuerySet
 from django.db.models import Model, permalink
-from django.utils import simplejson
+import json
 from django.utils.xmlutils import SimplerXMLGenerator
 from django.utils.encoding import smart_unicode
 from django.core.urlresolvers import reverse, NoReverseMatch
-from django.core.serializers.json import DateTimeAwareJSONEncoder
+from django.core.serializers.json import DjangoJSONEncoder
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.http import HttpResponse
@@ -287,5 +287,5 @@ class JSONEmitter(Emitter):
         if settings.DEBUG:
             indent = 4
 
-        seria = simplejson.dumps(self.construct(), cls=DateTimeAwareJSONEncoder, ensure_ascii=False, indent=indent)
+        seria = json.dumps(self.construct(), cls=DjangoJSONEncoder, ensure_ascii=False, indent=indent)
         return seria


### PR DESCRIPTION
# Description

Make compatible with Django 1.11