### PR TITLE
PLAT - 243 Django Upgrade - is_authenticated isn't a callable anymore

### DIFF
--- a/dynamicresponse/__init__.py
+++ b/dynamicresponse/__init__.py
@@ -1,2 +1,2 @@
-version_info = (0, 8, 0)
+version_info = (0, 9, 0)
 __version__ = '.'.join(map(str, version_info))

--- a/dynamicresponse/middleware/api.py
+++ b/dynamicresponse/middleware/api.py
@@ -65,7 +65,7 @@ class APIMiddleware(MiddlewareMixin):
         already containing HTTP authorization headers.
         """
 
-        if (not request.is_api) or (request.user.is_authenticated()):
+        if (not request.is_api) or request.user.is_authenticated:
             return False
         else:
             return self._get_auth_string(request) is not None


### PR DESCRIPTION
I had to do this change because it's not compatible with Django 2.2, the property **_is_authenticated_** is compatible with Django 1.11 and Django 2.2.